### PR TITLE
test(react): Stabilize useCountrySelector tests

### DIFF
--- a/packages/phone-mask-react/tests/unit/useCountrySelector.test.ts
+++ b/packages/phone-mask-react/tests/unit/useCountrySelector.test.ts
@@ -38,13 +38,20 @@ function setup(options: SetupOptions = {}) {
   return { result, simulateCloseComplete, unmount, onSelectCountry, onAfterSelect, searchEl };
 }
 
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
 testUseCountrySelector(setup, tools);
 
 function setupWithDom(initialCountryOption?: string) {
   const rootEl = document.createElement('div');
   vi.spyOn(rootEl, 'getBoundingClientRect').mockReturnValue(createRect(10, 30, 5, 120));
+  const rootRef = { current: rootEl };
 
   const dropdownEl = document.createElement('div');
+  const dropdownRef = { current: dropdownEl };
   const list = document.createElement('ul');
   const optionA = document.createElement('li');
   const optionB = document.createElement('li');
@@ -63,20 +70,23 @@ function setupWithDom(initialCountryOption?: string) {
 
   const searchEl = document.createElement('input');
   vi.spyOn(searchEl, 'focus').mockImplementation(() => {});
+  const searchRef = { current: searchEl };
   const selectorEl = document.createElement('div');
+  const selectorRef = { current: selectorEl };
+  const onSelectCountry = vi.fn();
 
   document.body.append(rootEl, dropdownEl, selectorEl);
 
   const { result, rerender, unmount } = renderHookWithProxy(
     ({ countryOption }: { countryOption?: string }) =>
       useCountrySelector({
-        rootRef: { current: rootEl },
-        dropdownRef: { current: dropdownEl },
-        searchRef: { current: searchEl },
-        selectorRef: { current: selectorEl },
+        rootRef,
+        dropdownRef,
+        searchRef,
+        selectorRef,
         locale: 'en',
         countryOption,
-        onSelectCountry: vi.fn()
+        onSelectCountry
       }),
     { initialProps: { countryOption: initialCountryOption } }
   );
@@ -114,6 +124,7 @@ describe('useCountrySelector DOM behavior (React)', () => {
   });
 
   afterEach(() => {
+    vi.clearAllTimers();
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
## Description

- **What does this PR do?**
  - _Stabilizes React unit test harness behavior for `useCountrySelector` after recent hook callback dependency refactors_
  - _Fixes CI coverage failures (`OOM` / worker timeout) by making test refs stable across rerenders and improving cleanup in the React test file_
  - _Scope is **tests only**; no production/runtime behavior changes in the React package source_

- **Why is this change needed?**
  - _After the recent React hook dependency updates (including `ada87a11e69a16690ae80c98a385ddb344fae071`), tests that recreated `{ current: ... }` refs on rerender caused callback/effect churn in the test environment_
  - _This does **not** represent a bug in library runtime code. In real usage, refs are stable (`useRef`), but tests were not mirroring that_
  - _Under coverage instrumentation, this mismatch caused memory growth and fork worker crashes_
  - _This PR aligns tests with real React usage and restores CI reliability_

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [x] Tests
- [ ] Other (describe below):

## Testing

- `pnpm test:unit:coverage`

## Screenshots (if applicable)

- N/A (test-only changes)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated
- [x] Tests added/updated
- [x] All tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure with enhanced cleanup procedures and refined test setup to ensure better test isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->