### PR TITLE
chore: Improve readme compare script

### DIFF
--- a/scripts/update-readme-benchmarks.mts
+++ b/scripts/update-readme-benchmarks.mts
@@ -122,7 +122,11 @@ const PHONE_ENGINE_PACKAGES = new Set([
 const PHONE_DATA_SOURCE_LABEL_OVERRIDES: Record<string, string> = {
   'react-international-phone': 'None'
 };
-const PACKAGES_WITHOUT_PHONE_DATA_SOURCE = new Set(Object.keys(PHONE_DATA_SOURCE_LABEL_OVERRIDES));
+const PACKAGES_WITHOUT_PHONE_DATA_SOURCE = new Set(
+  Object.entries(PHONE_DATA_SOURCE_LABEL_OVERRIDES)
+    .filter(([, label]) => label === 'None')
+    .map(([pkg]) => pkg)
+);
 
 const EXPORT_OVERHEAD_OVERRIDES: Record<string, ExportOverheadOverride[]> = {
   'vue-tel-input': [{ package: 'libphonenumber-js', exports: ['parsePhoneNumberFromString'] }],

--- a/scripts/update-readme-benchmarks.mts
+++ b/scripts/update-readme-benchmarks.mts
@@ -122,6 +122,7 @@ const PHONE_ENGINE_PACKAGES = new Set([
 const PHONE_DATA_SOURCE_LABEL_OVERRIDES: Record<string, string> = {
   'react-international-phone': 'None'
 };
+const PACKAGES_WITHOUT_PHONE_DATA_SOURCE = new Set(Object.keys(PHONE_DATA_SOURCE_LABEL_OVERRIDES));
 
 const EXPORT_OVERHEAD_OVERRIDES: Record<string, ExportOverheadOverride[]> = {
   'vue-tel-input': [{ package: 'libphonenumber-js', exports: ['parsePhoneNumberFromString'] }],
@@ -572,8 +573,16 @@ function renderPhoneDataSource(pkg: string, metric: PackageMetrics): string {
   return 'Included in package';
 }
 
-function sortRowsByTotalGzip(group: GroupDefinition, metrics: Map<string, PackageMetrics>): GroupRow[] {
+function hasPhoneDataSource(pkg: string): boolean {
+  return !PACKAGES_WITHOUT_PHONE_DATA_SOURCE.has(pkg);
+}
+
+function sortRowsForComparison(group: GroupDefinition, metrics: Map<string, PackageMetrics>): GroupRow[] {
   return [...group.rows].sort((a, b) => {
+    const aHasPhoneDataSource = hasPhoneDataSource(a.pkg);
+    const bHasPhoneDataSource = hasPhoneDataSource(b.pkg);
+    if (aHasPhoneDataSource !== bHasPhoneDataSource) return aHasPhoneDataSource ? -1 : 1;
+
     const aMetric = metrics.get(a.pkg);
     const bMetric = metrics.get(b.pkg);
     const aSize =
@@ -590,7 +599,7 @@ function sortRowsByTotalGzip(group: GroupDefinition, metrics: Map<string, Packag
 }
 
 function renderGroupBestLine(group: GroupDefinition, metrics: Map<string, PackageMetrics>): string | null {
-  const ranked = sortRowsByTotalGzip(group, metrics);
+  const ranked = sortRowsForComparison(group, metrics);
   const winner = ranked.find((row) => {
     const metric = metrics.get(row.pkg);
     return metric && Number.isFinite(metric.comparableGzip);
@@ -611,7 +620,7 @@ function renderGroupSection(group: GroupDefinition, metrics: Map<string, Package
     '| --- | ---: | --- | ---: | ---: | ---: |'
   ];
 
-  const rows = sortRowsByTotalGzip(group, metrics);
+  const rows = sortRowsForComparison(group, metrics);
   for (const row of rows) {
     lines.push(renderMetricRow(row, metrics.get(row.pkg)));
   }
@@ -644,6 +653,7 @@ function renderSection(
     '*`Gzip` is measured locally by this repository benchmark pipeline (isolated temp install + minified bundle build).*',
     '*`Data overhead` is additional phone-data gzip excluded from raw package gzip (e.g. required peer engines).*',
     '*`Total gzip` = `Gzip` + `Data overhead`.*',
+    '*Packages without a phone data source are listed after data-backed packages; each bucket is sorted by `Total gzip`.*',
     ''
   ];
   const groupSections = GROUPS.flatMap((group) => renderGroupSection(group, metrics));


### PR DESCRIPTION
## Description

- **What does this PR do?**
  - _Updates the README benchmark generator so package comparison tables rank libraries with a phone data source before libraries without one_
  - _Keeps the existing `Total gzip` size sorting inside each bucket_
  - _Adds a generated README note explaining that packages without a phone data source are listed after data-backed packages_

- **Why is this change needed?**
  - _The previous comparison was sorted only by raw/comparable gzip size, so any library could be promoted even though its package does not include or depend on phone mask/country data_
  - _This made the benchmark less fair for libraries, which ship a complete phone input experience backed by country/mask data_
  - _The updated ranking keeps bundle size visible while making the comparison criteria more accurate_

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Documentation update
- [ ] Tests
- [x] Other: benchmark generation logic

## Testing

- `pnpm readme:benchmarks`

## Screenshots (if applicable)

- N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated
- [x] Tests added/updated
- [x] All tests passing

## Manual Coverage (Optional)

[![Run Coverage Workflow](https://img.shields.io/badge/Run%20Coverage%20Workflow-GitHub%20Actions-2ea44f?logo=githubactions&logoColor=white)](https://github.com/DeSource-Labs/phone-mask/actions/workflows/coverage.yml)

_Maintainers only (`write/maintain/admin` access): open the workflow, click `Run workflow`, and set `pr_number` to this PR number to post/update a coverage comment on this PR_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized benchmark listings in README with packages featuring phone data source coverage appearing first, followed by packages without it. Both groups are sorted by Total gzip size. Updated README documentation to explain the new ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->