### PR TITLE
chore: Automate google sync release

### DIFF
--- a/.github/workflows/release-mask-sync.yml
+++ b/.github/workflows/release-mask-sync.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -74,7 +75,6 @@ jobs:
 
             cc @stefashkaa
           branch: chore/release-mask-sync
-          branch-suffix: timestamp
           labels: |
             automation
             chore

--- a/.github/workflows/release-mask-sync.yml
+++ b/.github/workflows/release-mask-sync.yml
@@ -1,0 +1,97 @@
+name: Release mask sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: 'Optional tag, branch, or SHA to compare against. Defaults to the latest reachable semver release tag.'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-mask-sync
+  cancel-in-progress: false
+
+jobs:
+  create-release-pr:
+    name: Create release PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.10.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 25
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create mask sync changeset
+        id: mask-sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MASK_SYNC_BASE_REF: ${{ inputs.base-ref }}
+        run: pnpm changeset:mask-sync
+
+      - name: Version packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm changeset:version
+
+      - name: Format changelog dependency sections
+        run: pnpm changeset:format-changelogs
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: Release packages'
+          title: 'chore: Release packages'
+          body: |
+            Automated release PR for Google libphonenumber country mask changes.
+
+            Generated changelog entry:
+
+            ${{ steps.mask-sync.outputs.changelog }}
+
+            After this PR is squash-merged, `.github/workflows/release.yml` will publish the updated packages to npm.
+
+            cc @stefashkaa
+          branch: chore/release-mask-sync
+          branch-suffix: timestamp
+          labels: |
+            automation
+            chore
+            release
+          assignees: |
+            stefashkaa
+          reviewers: |
+            stefashkaa
+          signoff: false
+          delete-branch: true
+          draft: false
+
+      - name: PR created output
+        if: steps.cpr.outputs.pull-request-number != ''
+        run: |
+          echo "Created PR #${{ steps.cpr.outputs.pull-request-number }}"
+
+      - name: No changes detected
+        if: steps.cpr.outputs.pull-request-number == ''
+        run: echo "No changes to commit; skipping PR."

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "vercel-build": "pnpm build && pnpm dev:prepare && pnpm build:demo",
     "gen": "pnpm --filter phone-mask gen",
     "changeset": "changeset",
+    "changeset:format-changelogs": "node scripts/format-changelog-dependencies.mts",
+    "changeset:mask-sync": "node scripts/create-mask-sync-changeset.mts",
     "changeset:version": "changeset version",
     "changeset:publish": "pnpm build && changeset publish --no-git-tag",
     "readme:benchmarks": "node scripts/update-readme-benchmarks.mts",

--- a/scripts/create-mask-sync-changeset.mts
+++ b/scripts/create-mask-sync-changeset.mts
@@ -1,0 +1,271 @@
+import { execFileSync } from 'node:child_process';
+import { appendFile, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+type MaskValue = string | string[];
+type MaskMapping = Record<string, MaskValue>;
+type ChangesetsConfig = {
+  fixed?: string[][];
+};
+type PackageJson = {
+  name?: string;
+  private?: boolean;
+};
+type CountryChangeKind = 'added' | 'removed' | 'updated';
+type CountryChange = {
+  code: string;
+  kind: CountryChangeKind;
+  name: string;
+};
+
+const DATA_JSON_PATH = 'packages/phone-mask/src/data.json';
+const DATA_CHANGE_FILES = new Set([
+  DATA_JSON_PATH,
+  'packages/phone-mask/src/data.min.js',
+  'packages/phone-mask/src/data-types.ts'
+]);
+const CHANGESET_PATH = '.changeset/google-libphonenumber-mask-sync.md';
+const CHANGESET_LEVEL = 'patch';
+const CHANGE_KIND_ORDER: Record<CountryChangeKind, number> = {
+  added: 0,
+  removed: 1,
+  updated: 2
+};
+const CHANGE_LABEL_BY_KIND: Record<CountryChangeKind, string> = {
+  added: 'support',
+  removed: 'is no longer supported',
+  updated: 'updates'
+};
+const regionDisplayNames = new Intl.DisplayNames(['en'], { type: 'region' });
+
+const baseRef = process.env.MASK_SYNC_BASE_REF?.trim() || resolveLatestReleaseTag();
+const dryRun = process.env.MASK_SYNC_DRY_RUN === '1' || process.env.MASK_SYNC_DRY_RUN === 'true';
+
+assertGitRef(baseRef);
+await assertNoActiveChangesets();
+
+const previousData = parseMaskMapping(gitShow(`${baseRef}:${DATA_JSON_PATH}`), `${baseRef}:${DATA_JSON_PATH}`);
+const currentData = parseMaskMapping(await readFile(DATA_JSON_PATH, 'utf8'), DATA_JSON_PATH);
+const changes = findCountryChanges(previousData, currentData);
+
+if (changes.length === 0) {
+  throw new Error(`No country mask changes detected between ${baseRef} and the current ${DATA_JSON_PATH}`);
+}
+
+const packageNames = await readReleasePackageNames();
+if (packageNames.length === 0) {
+  throw new Error('Could not resolve any packages to include in the mask sync changeset.');
+}
+
+const changelogEntry = formatChangelogEntry(changes);
+const changeset = formatChangeset(packageNames, changelogEntry);
+const nonDataFiles = changedFilesSince(baseRef).filter((file) => !DATA_CHANGE_FILES.has(file));
+
+if (dryRun) {
+  console.log(`Dry run: would create ${CHANGESET_PATH}`);
+  console.log(changeset.trimEnd());
+} else {
+  await writeFile(CHANGESET_PATH, changeset);
+  console.log(`Created ${CHANGESET_PATH}`);
+}
+
+if (nonDataFiles.length > 0) {
+  const preview = nonDataFiles.slice(0, 20).join(', ');
+  const suffix = nonDataFiles.length > 20 ? `, and ${nonDataFiles.length - 20} more` : '';
+  console.warn(`::warning title=Non-data changes since ${baseRef}::${preview}${suffix}`);
+}
+
+await writeStepSummary(baseRef, changes, changelogEntry, nonDataFiles);
+await writeStepOutputs(changes.length, changelogEntry);
+
+console.log(
+  `Prepared mask sync changeset for ${changes.length} country change(s) across ${packageNames.length} package(s).`
+);
+
+function resolveLatestReleaseTag(): string {
+  const tags = execFileSync('git', ['tag', '--merged', 'HEAD', '--sort=-version:refname'], { encoding: 'utf8' })
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter((tag) => /^(?:v)?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(tag));
+
+  const latestTag = tags[0];
+  if (!latestTag) {
+    throw new Error('Could not resolve the latest reachable semver release tag. Set MASK_SYNC_BASE_REF explicitly.');
+  }
+
+  return latestTag;
+}
+
+function assertGitRef(ref: string): void {
+  execFileSync('git', ['rev-parse', '--verify', `${ref}^{commit}`], { stdio: 'ignore' });
+}
+
+function gitShow(refPath: string): string {
+  return execFileSync('git', ['show', refPath], { encoding: 'utf8' });
+}
+
+function changedFilesSince(ref: string): string[] {
+  return execFileSync('git', ['diff', '--name-only', `${ref}..HEAD`], { encoding: 'utf8' })
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean);
+}
+
+async function assertNoActiveChangesets(): Promise<void> {
+  const entries = await readdir('.changeset');
+  const activeChangesets = entries.filter((entry) => entry.endsWith('.md') && entry !== 'README.md');
+
+  if (activeChangesets.length > 0) {
+    throw new Error(
+      `Active changeset files already exist: ${activeChangesets.join(', ')}. Resolve them before creating an automated mask sync release.`
+    );
+  }
+}
+
+async function readReleasePackageNames(): Promise<string[]> {
+  const config = JSON.parse(await readFile('.changeset/config.json', 'utf8')) as ChangesetsConfig;
+  const fixedPackageNames = unique((config.fixed ?? []).flat());
+
+  if (fixedPackageNames.length > 0) {
+    return fixedPackageNames;
+  }
+
+  const packageDirectories = await readdir('packages', { withFileTypes: true });
+  const packageNames = await Promise.all(
+    packageDirectories
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const packageJsonPath = path.join('packages', entry.name, 'package.json');
+        const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as PackageJson;
+        return packageJson.private === true ? null : packageJson.name;
+      })
+  );
+
+  return packageNames.filter((name): name is string => Boolean(name));
+}
+
+function parseMaskMapping(raw: string, label: string): MaskMapping {
+  const parsed = JSON.parse(raw) as unknown;
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${label} must contain a JSON object`);
+  }
+
+  const mapping = parsed as Record<string, unknown>;
+
+  for (const [code, value] of Object.entries(mapping)) {
+    if (!/^[A-Z]{2}$/.test(code)) {
+      throw new Error(`${label} contains an invalid country code: ${code}`);
+    }
+
+    if (typeof value === 'string') continue;
+
+    if (Array.isArray(value) && value.every((entry) => typeof entry === 'string')) {
+      continue;
+    }
+
+    throw new Error(`${label} contains an invalid mask value for ${code}`);
+  }
+
+  return mapping as MaskMapping;
+}
+
+function findCountryChanges(previousData: MaskMapping, currentData: MaskMapping): CountryChange[] {
+  const previousCodes = new Set(Object.keys(previousData));
+  const currentCodes = new Set(Object.keys(currentData));
+  const changes: CountryChange[] = [];
+
+  for (const code of currentCodes) {
+    if (!previousCodes.has(code)) {
+      changes.push(countryChange(code, 'added'));
+    }
+  }
+
+  for (const code of previousCodes) {
+    if (!currentCodes.has(code)) {
+      changes.push(countryChange(code, 'removed'));
+    }
+  }
+
+  for (const code of currentCodes) {
+    if (previousCodes.has(code) && !isSameMaskValue(previousData[code], currentData[code])) {
+      changes.push(countryChange(code, 'updated'));
+    }
+  }
+
+  return changes.sort(
+    (a, b) => CHANGE_KIND_ORDER[a.kind] - CHANGE_KIND_ORDER[b.kind] || a.name.localeCompare(b.name, 'en')
+  );
+}
+
+function countryChange(code: string, kind: CountryChangeKind): CountryChange {
+  return {
+    code,
+    kind,
+    name: regionDisplayNames.of(code) ?? code
+  };
+}
+
+function isSameMaskValue(left: MaskValue, right: MaskValue): boolean {
+  const leftMasks = toMaskArray(left);
+  const rightMasks = toMaskArray(right);
+
+  return leftMasks.length === rightMasks.length && leftMasks.every((mask, index) => mask === rightMasks[index]);
+}
+
+function toMaskArray(value: MaskValue): string[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+function formatChangeset(packageNames: string[], changelogEntry: string): string {
+  const releaseFrontmatter = packageNames.map((packageName) => `'${packageName}': ${CHANGESET_LEVEL}`).join('\n');
+
+  return `---\n${releaseFrontmatter}\n---\n\n${changelogEntry}\n`;
+}
+
+function formatChangelogEntry(changes: CountryChange[]): string {
+  const lines = changes.map(
+    (change) =>
+      `  - Sync country masks with google-libphonenumber (${countryFlag(change.code)} ${change.name} ${CHANGE_LABEL_BY_KIND[change.kind]})`
+  );
+
+  return ['Core Upgrades:', ...lines].join('\n');
+}
+
+function countryFlag(countryCode: string): string {
+  return [...countryCode].map((char) => String.fromCodePoint(0x1f1e6 + char.charCodeAt(0) - 65)).join('');
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+async function writeStepSummary(
+  ref: string,
+  changes: CountryChange[],
+  changelogEntry: string,
+  nonDataFiles: string[]
+): Promise<void> {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const nonDataSection =
+    nonDataFiles.length === 0
+      ? 'No non-data files changed since the compare ref.'
+      : `Non-data files changed since the compare ref:\n\n${nonDataFiles.map((file) => `- \`${file}\``).join('\n')}`;
+
+  await appendFile(
+    summaryPath,
+    `## Google libphonenumber mask sync\n\nBase ref: \`${ref}\`\n\nCountry changes: ${changes.length}\n\n${changelogEntry}\n\n${nonDataSection}\n`
+  );
+}
+
+async function writeStepOutputs(changeCount: number, changelogEntry: string): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+
+  const delimiter = `CHANGELOG_${Date.now()}`;
+  await appendFile(outputPath, `changeset_path=${CHANGESET_PATH}\n`);
+  await appendFile(outputPath, `change_count=${changeCount}\n`);
+  await appendFile(outputPath, `changelog<<${delimiter}\n${changelogEntry}\n${delimiter}\n`);
+}

--- a/scripts/create-mask-sync-changeset.mts
+++ b/scripts/create-mask-sync-changeset.mts
@@ -17,6 +17,13 @@ type CountryChange = {
   kind: CountryChangeKind;
   name: string;
 };
+type SemverTag = {
+  tag: string;
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+};
 
 const DATA_JSON_PATH = 'packages/phone-mask/src/data.json';
 const DATA_CHANGE_FILES = new Set([
@@ -27,6 +34,7 @@ const DATA_CHANGE_FILES = new Set([
 const CHANGESET_PATH = '.changeset/google-libphonenumber-mask-sync.md';
 const CHANGESET_LEVEL = 'patch';
 const GIT_BINARY = '/usr/bin/git';
+const PACKAGE_CHANGELOG_RE = /^packages\/[^/]+\/CHANGELOG\.md$/;
 const CHANGE_KIND_ORDER: Record<CountryChangeKind, number> = {
   added: 0,
   removed: 1,
@@ -60,7 +68,15 @@ if (packageNames.length === 0) {
 
 const changelogEntry = formatChangelogEntry(changes);
 const changeset = formatChangeset(packageNames, changelogEntry);
-const nonDataFiles = changedFilesSince(baseRef).filter((file) => !DATA_CHANGE_FILES.has(file));
+const nonDataFiles = changedFilesSince(baseRef).filter(isNonDataFile);
+const releaseBlockingFiles = nonDataFiles.filter(isReleaseBlockingFile);
+
+if (releaseBlockingFiles.length > 0) {
+  await writeStepSummary(baseRef, changes, changelogEntry, nonDataFiles, releaseBlockingFiles);
+  throw new Error(
+    `Found publish-relevant non-data package changes since ${baseRef}: ${releaseBlockingFiles.join(', ')}. Release those changes first or rerun with a newer base ref.`
+  );
+}
 
 if (dryRun) {
   console.log(`Dry run: would create ${CHANGESET_PATH}`);
@@ -73,10 +89,10 @@ if (dryRun) {
 if (nonDataFiles.length > 0) {
   const preview = nonDataFiles.slice(0, 20).join(', ');
   const suffix = nonDataFiles.length > 20 ? `, and ${nonDataFiles.length - 20} more` : '';
-  console.warn(`::warning title=Non-data changes since ${baseRef}::${preview}${suffix}`);
+  console.warn(`::notice title=Non-published non-data changes since ${baseRef}::${preview}${suffix}`);
 }
 
-await writeStepSummary(baseRef, changes, changelogEntry, nonDataFiles);
+await writeStepSummary(baseRef, changes, changelogEntry, nonDataFiles, releaseBlockingFiles);
 await writeStepOutputs(changes.length, changelogEntry);
 
 console.log(
@@ -84,12 +100,14 @@ console.log(
 );
 
 function resolveLatestReleaseTag(): string {
-  const latestTag = execFileSync(GIT_BINARY, ['tag', '--merged', 'HEAD', '--sort=-version:refname'], {
-    encoding: 'utf8'
-  })
+  const tags = execFileSync(GIT_BINARY, ['tag', '--merged', 'HEAD'], { encoding: 'utf8' })
     .split('\n')
     .map((tag) => tag.trim())
-    .find(isSemverTag);
+    .map(parseSemverTag)
+    .filter((tag): tag is SemverTag => tag !== null)
+    .sort(compareSemverTags);
+
+  const latestTag = tags.at(-1)?.tag;
 
   if (!latestTag) {
     throw new Error('Could not resolve the latest reachable semver release tag. Set MASK_SYNC_BASE_REF explicitly.');
@@ -113,8 +131,72 @@ function changedFilesSince(ref: string): string[] {
     .filter(Boolean);
 }
 
-function isSemverTag(tag: string): boolean {
-  return /^(?:v)?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(tag);
+function isNonDataFile(file: string): boolean {
+  return !DATA_CHANGE_FILES.has(file);
+}
+
+function isReleaseBlockingFile(file: string): boolean {
+  return file.startsWith('packages/') && !PACKAGE_CHANGELOG_RE.test(file);
+}
+
+function parseSemverTag(tag: string): SemverTag | null {
+  const match = /^(?:v)?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(tag);
+  if (!match) return null;
+
+  return {
+    tag,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4]?.split('.') ?? []
+  };
+}
+
+function compareSemverTags(left: SemverTag, right: SemverTag): number {
+  return (
+    compareNumbers(left.major, right.major) ||
+    compareNumbers(left.minor, right.minor) ||
+    compareNumbers(left.patch, right.patch) ||
+    comparePrerelease(left.prerelease, right.prerelease)
+  );
+}
+
+function compareNumbers(left: number, right: number): number {
+  return left - right;
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) return 0;
+  if (left.length === 0) return 1;
+  if (right.length === 0) return -1;
+
+  const maxLength = Math.max(left.length, right.length);
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftIdentifier = left[index];
+    const rightIdentifier = right[index];
+
+    if (leftIdentifier === undefined) return -1;
+    if (rightIdentifier === undefined) return 1;
+
+    const comparison = comparePrereleaseIdentifier(leftIdentifier, rightIdentifier);
+    if (comparison !== 0) return comparison;
+  }
+
+  return 0;
+}
+
+function comparePrereleaseIdentifier(left: string, right: string): number {
+  const leftNumeric = /^\d+$/.test(left);
+  const rightNumeric = /^\d+$/.test(right);
+
+  if (leftNumeric && rightNumeric) {
+    return compareNumbers(Number(left), Number(right));
+  }
+
+  if (leftNumeric) return -1;
+  if (rightNumeric) return 1;
+
+  return left.localeCompare(right, 'en');
 }
 
 async function assertNoActiveChangesets(): Promise<void> {
@@ -260,7 +342,8 @@ async function writeStepSummary(
   ref: string,
   changes: CountryChange[],
   changelogEntry: string,
-  nonDataFiles: string[]
+  nonDataFiles: string[],
+  releaseBlockingFiles: string[]
 ): Promise<void> {
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (!summaryPath) return;
@@ -269,10 +352,14 @@ async function writeStepSummary(
     nonDataFiles.length === 0
       ? 'No non-data files changed since the compare ref.'
       : `Non-data files changed since the compare ref:\n\n${nonDataFiles.map(formatMarkdownFileListItem).join('\n')}`;
+  const releaseBlockingSection =
+    releaseBlockingFiles.length === 0
+      ? 'No publish-relevant non-data package files changed since the compare ref.'
+      : `Publish-relevant non-data package files changed since the compare ref:\n\n${releaseBlockingFiles.map(formatMarkdownFileListItem).join('\n')}`;
 
   await appendFile(
     summaryPath,
-    `## Google libphonenumber mask sync\n\nBase ref: \`${ref}\`\n\nCountry changes: ${changes.length}\n\n${changelogEntry}\n\n${nonDataSection}\n`
+    `## Google libphonenumber mask sync\n\nBase ref: \`${ref}\`\n\nCountry changes: ${changes.length}\n\n${changelogEntry}\n\n${nonDataSection}\n\n${releaseBlockingSection}\n`
   );
 }
 

--- a/scripts/create-mask-sync-changeset.mts
+++ b/scripts/create-mask-sync-changeset.mts
@@ -26,6 +26,7 @@ const DATA_CHANGE_FILES = new Set([
 ]);
 const CHANGESET_PATH = '.changeset/google-libphonenumber-mask-sync.md';
 const CHANGESET_LEVEL = 'patch';
+const GIT_BINARY = '/usr/bin/git';
 const CHANGE_KIND_ORDER: Record<CountryChangeKind, number> = {
   added: 0,
   removed: 1,
@@ -83,12 +84,13 @@ console.log(
 );
 
 function resolveLatestReleaseTag(): string {
-  const tags = execFileSync('git', ['tag', '--merged', 'HEAD', '--sort=-version:refname'], { encoding: 'utf8' })
+  const latestTag = execFileSync(GIT_BINARY, ['tag', '--merged', 'HEAD', '--sort=-version:refname'], {
+    encoding: 'utf8'
+  })
     .split('\n')
     .map((tag) => tag.trim())
-    .filter((tag) => /^(?:v)?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(tag));
+    .find(isSemverTag);
 
-  const latestTag = tags[0];
   if (!latestTag) {
     throw new Error('Could not resolve the latest reachable semver release tag. Set MASK_SYNC_BASE_REF explicitly.');
   }
@@ -97,18 +99,22 @@ function resolveLatestReleaseTag(): string {
 }
 
 function assertGitRef(ref: string): void {
-  execFileSync('git', ['rev-parse', '--verify', `${ref}^{commit}`], { stdio: 'ignore' });
+  execFileSync(GIT_BINARY, ['rev-parse', '--verify', `${ref}^{commit}`], { stdio: 'ignore' });
 }
 
 function gitShow(refPath: string): string {
-  return execFileSync('git', ['show', refPath], { encoding: 'utf8' });
+  return execFileSync(GIT_BINARY, ['show', refPath], { encoding: 'utf8' });
 }
 
 function changedFilesSince(ref: string): string[] {
-  return execFileSync('git', ['diff', '--name-only', `${ref}..HEAD`], { encoding: 'utf8' })
+  return execFileSync(GIT_BINARY, ['diff', '--name-only', `${ref}..HEAD`], { encoding: 'utf8' })
     .split('\n')
     .map((file) => file.trim())
     .filter(Boolean);
+}
+
+function isSemverTag(tag: string): boolean {
+  return /^(?:v)?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(tag);
 }
 
 async function assertNoActiveChangesets(): Promise<void> {
@@ -233,7 +239,17 @@ function formatChangelogEntry(changes: CountryChange[]): string {
 }
 
 function countryFlag(countryCode: string): string {
-  return [...countryCode].map((char) => String.fromCodePoint(0x1f1e6 + char.charCodeAt(0) - 65)).join('');
+  return [...countryCode].map(countryCodeLetterToRegionalIndicator).join('');
+}
+
+function countryCodeLetterToRegionalIndicator(char: string): string {
+  const codePoint = char.codePointAt(0);
+
+  if (codePoint === undefined) {
+    return '';
+  }
+
+  return String.fromCodePoint(0x1f1e6 + codePoint - 65);
 }
 
 function unique(values: string[]): string[] {
@@ -252,12 +268,16 @@ async function writeStepSummary(
   const nonDataSection =
     nonDataFiles.length === 0
       ? 'No non-data files changed since the compare ref.'
-      : `Non-data files changed since the compare ref:\n\n${nonDataFiles.map((file) => `- \`${file}\``).join('\n')}`;
+      : `Non-data files changed since the compare ref:\n\n${nonDataFiles.map(formatMarkdownFileListItem).join('\n')}`;
 
   await appendFile(
     summaryPath,
     `## Google libphonenumber mask sync\n\nBase ref: \`${ref}\`\n\nCountry changes: ${changes.length}\n\n${changelogEntry}\n\n${nonDataSection}\n`
   );
+}
+
+function formatMarkdownFileListItem(file: string): string {
+  return `- \`${file}\``;
 }
 
 async function writeStepOutputs(changeCount: number, changelogEntry: string): Promise<void> {

--- a/scripts/format-changelog-dependencies.mts
+++ b/scripts/format-changelog-dependencies.mts
@@ -1,0 +1,48 @@
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const packageEntries = await readdir('packages', { withFileTypes: true });
+let formattedCount = 0;
+
+for (const entry of packageEntries) {
+  if (!entry.isDirectory()) continue;
+
+  const changelogPath = path.join('packages', entry.name, 'CHANGELOG.md');
+  const original = await readOptionalFile(changelogPath);
+  if (original === null) continue;
+
+  const formatted = formatUpdatedDependenciesSpacing(original);
+  if (formatted === original) continue;
+
+  await writeFile(changelogPath, formatted);
+  formattedCount += 1;
+}
+
+console.log(`Formatted dependency changelog spacing in ${formattedCount} file(s).`);
+
+async function readOptionalFile(filePath: string): Promise<string | null> {
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function formatUpdatedDependenciesSpacing(markdown: string): string {
+  const lines = markdown.split('\n');
+  const formattedLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith('- Updated dependencies [') && formattedLines.at(-1)?.trim()) {
+      formattedLines.push('');
+    }
+
+    formattedLines.push(line);
+  }
+
+  return formattedLines.join('\n');
+}


### PR DESCRIPTION
## Description

- **What does this PR do?**
  - Adds a manually triggered GitHub workflow that creates a release PR for merged Google libphonenumber mask sync changes
  - Adds a script that compares current mask data against the latest release tag, generates a patch changeset for all publishable packages, and formats the changelog entries
  - Adds a small changelog formatter to preserve the existing blank-line style before `Updated dependencies` sections

- **Why is this change needed?**
  - Weekly generated country mask updates can be important to deliver quickly, but the release preparation currently requires manual changeset/version/PR steps
  - This workflow automates that release PR creation after the weekly data PR is reviewed and merged

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Tests
- [x] Other (describe below): GitHub Actions release automation

## Testing

- Ran mask-sync changeset generation in dry-run mode:
  - `MASK_SYNC_BASE_REF=1.6.0 MASK_SYNC_DRY_RUN=1 pnpm changeset:mask-sync`
- Verified the generated changeset produces the expected Faroe Islands changelog entry
- Ran `pnpm changeset:version` in a temporary worktree to verify final changelog output
- Verified dependency changelog spacing formatter
- Ran formatting and lint checks

## Screenshots (if applicable)

- N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated
- [x] Tests added/updated
- [x] All tests passing

## Manual Coverage (Optional)

[![Run Coverage Workflow](https://img.shields.io/badge/Run%20Coverage%20Workflow-GitHub%20Actions-2ea44f?logo=githubactions&logoColor=white)](https://github.com/DeSource-Labs/phone-mask/actions/workflows/coverage.yml)

_Maintainers only (`write/maintain/admin` access): open the workflow, click `Run workflow`, and set `pr_number` to this PR number to post/update a coverage comment on this PR_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated synchronization for release mask changes.
  * Release updates now detect added, removed, and modified country masks and generate corresponding changelog entries.
  * Added support for previewing changes before creating a release update.

* **Improvements**
  * Changelogs are automatically formatted for clearer dependency updates.
  * Release workflows validate comparison references and identify unrelated changes before submitting updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->